### PR TITLE
Remove chart directory icon from home navbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,11 +31,6 @@
             <span class="glyphicon glyphicon-home collapsed-element"></span>
           </a>
         </li>
-        <li>
-          <a href="http://ryan2706.github.io/GEAR/charts/chartDir.html" title="Chord Chart">
-            <span class="glyphicon glyphicon-book collapsed-element"></span>
-          </a>
-        </li>
         <li class="dropdown">
           <a class="dropdown-toggle" data-toggle="dropdown" href="#">ABOUT
           <span class="caret"></span></a>


### PR DESCRIPTION
## Summary
- drop chord chart link from `index.html` navbar in favor of existing search page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e0ea20a7083338faf05a1ed9f9fd3