### PR TITLE
Use glyphicon for docx icon

### DIFF
--- a/about/aboutCOTL.html
+++ b/about/aboutCOTL.html
@@ -58,7 +58,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/about/aboutSite.html
+++ b/about/aboutSite.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/A/A Broken Spirit.html
+++ b/charts/A/A Broken Spirit.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/A/A Place At Your Altar.html
+++ b/charts/A/A Place At Your Altar.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/A/A Pure Heart.html
+++ b/charts/A/A Pure Heart.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/A/A Voice for Worship.html
+++ b/charts/A/A Voice for Worship.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/A/Abide.html
+++ b/charts/A/Abide.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/A/Above All Else.html
+++ b/charts/A/Above All Else.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/A/Above All.html
+++ b/charts/A/Above All.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/A/Ah Lord God.html
+++ b/charts/A/Ah Lord God.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/A/Alabaster Jar.html
+++ b/charts/A/Alabaster Jar.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/A/All Hail The Power of Jesus' Name.html
+++ b/charts/A/All Hail The Power of Jesus' Name.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/A/All Heaven Declares.html
+++ b/charts/A/All Heaven Declares.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/A/All I Need is You.html
+++ b/charts/A/All I Need is You.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/A/All Nations.html
+++ b/charts/A/All Nations.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/A/All Of My Days.html
+++ b/charts/A/All Of My Days.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/A/All The Earth Will Sing Your Praises.html
+++ b/charts/A/All The Earth Will Sing Your Praises.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/A/All The Heavens.html
+++ b/charts/A/All The Heavens.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/A/All To Jesus I Surrender.html
+++ b/charts/A/All To Jesus I Surrender.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/A/All on the Altar.html
+++ b/charts/A/All on the Altar.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/A/All the Earth.html
+++ b/charts/A/All the Earth.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/A/Amazing Grace (My Chains are Gone).html
+++ b/charts/A/Amazing Grace (My Chains are Gone).html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/A/Amazing Grace.html
+++ b/charts/A/Amazing Grace.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/A/Ancient of Days (Though the nations rage).html
+++ b/charts/A/Ancient of Days (Though the nations rage).html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/A/Ancient of Days.html
+++ b/charts/A/Ancient of Days.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/A/Angels We Have Heard On High.html
+++ b/charts/A/Angels We Have Heard On High.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/A/Arise (One Thing We Ask of You).html
+++ b/charts/A/Arise (One Thing We Ask of You).html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/A/As The Deer.html
+++ b/charts/A/As The Deer.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/A/As We Gather.html
+++ b/charts/A/As We Gather.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/A/As We Worship (in Your presence).html
+++ b/charts/A/As We Worship (in Your presence).html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/A/Ascribe Greatness To Our God.html
+++ b/charts/A/Ascribe Greatness To Our God.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/A/Ascribe To The Lord.html
+++ b/charts/A/Ascribe To The Lord.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/A/At the Cross (Love Ran Red).html
+++ b/charts/A/At the Cross (Love Ran Red).html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/A/At the Cross.html
+++ b/charts/A/At the Cross.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/A/Awesome God.html
+++ b/charts/A/Awesome God.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/A/Awesome In This Place (God is Awesome).html
+++ b/charts/A/Awesome In This Place (God is Awesome).html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/A/Awesome In This Place.html
+++ b/charts/A/Awesome In This Place.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/B/Be Enthroned.html
+++ b/charts/B/Be Enthroned.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/B/Be Still for the Presence of the Lord.html
+++ b/charts/B/Be Still for the Presence of the Lord.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/B/Be Thou My Vision.html
+++ b/charts/B/Be Thou My Vision.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/B/Be With You (I live to worship You).html
+++ b/charts/B/Be With You (I live to worship You).html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/B/Beautiful Saviour.html
+++ b/charts/B/Beautiful Saviour.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/B/Because He Lives.html
+++ b/charts/B/Because He Lives.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/B/Before the Throne of God Above.html
+++ b/charts/B/Before the Throne of God Above.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/B/Behold (Then sings my soul).html
+++ b/charts/B/Behold (Then sings my soul).html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/B/Better Is One Day.html
+++ b/charts/B/Better Is One Day.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/B/Blessed Assurance.html
+++ b/charts/B/Blessed Assurance.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/B/Blessed Be Your Name.html
+++ b/charts/B/Blessed Be Your Name.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/B/Build My Life.html
+++ b/charts/B/Build My Life.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/C/Came to My Rescue.html
+++ b/charts/C/Came to My Rescue.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/C/Can't Stop Singing.html
+++ b/charts/C/Can't Stop Singing.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/C/Captain.html
+++ b/charts/C/Captain.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/C/Celebrate Jesus Celebrate.html
+++ b/charts/C/Celebrate Jesus Celebrate.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/C/Change My Heart O God.html
+++ b/charts/C/Change My Heart O God.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/C/Christ be Magnified.html
+++ b/charts/C/Christ be Magnified.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/C/Christ is Enough.html
+++ b/charts/C/Christ is Enough.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/C/Christmas isn't Christmas.html
+++ b/charts/C/Christmas isn't Christmas.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/C/Come Holy Spirit (City Harvest Church).html
+++ b/charts/C/Come Holy Spirit (City Harvest Church).html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/C/Come Thou Fount (I Will Sing).html
+++ b/charts/C/Come Thou Fount (I Will Sing).html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/C/Come, Now is the Time to Worship.html
+++ b/charts/C/Come, Now is the Time to Worship.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/C/Complete.html
+++ b/charts/C/Complete.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/C/Consuming Fire.html
+++ b/charts/C/Consuming Fire.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/C/Cornerstone.html
+++ b/charts/C/Cornerstone.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/C/Crown Him + Majesty.html
+++ b/charts/C/Crown Him + Majesty.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/D/Dance With Me.html
+++ b/charts/D/Dance With Me.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/D/Deep Cries Out.html
+++ b/charts/D/Deep Cries Out.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/D/Deeper in Love.html
+++ b/charts/D/Deeper in Love.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/D/Desert Song.html
+++ b/charts/D/Desert Song.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/D/Did You Feel the Mountain Tremble.html
+++ b/charts/D/Did You Feel the Mountain Tremble.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/D/Do It Again.html
+++ b/charts/D/Do It Again.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/D/Down At Your Feet.html
+++ b/charts/D/Down At Your Feet.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/D/Draw Me Close.html
+++ b/charts/D/Draw Me Close.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/D/Dwell In Your House.html
+++ b/charts/D/Dwell In Your House.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/E/Eagle's Wings.html
+++ b/charts/E/Eagle's Wings.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/E/Empower Me.html
+++ b/charts/E/Empower Me.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/E/Ever Be.html
+++ b/charts/E/Ever Be.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/E/Everlasting God.html
+++ b/charts/E/Everlasting God.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/E/Everything that has Breath.html
+++ b/charts/E/Everything that has Breath.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/F/Faith.html
+++ b/charts/F/Faith.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/F/Fall (Holy Spirit come in power).html
+++ b/charts/F/Fall (Holy Spirit come in power).html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/F/For All You've Done.html
+++ b/charts/F/For All You've Done.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/F/For You Alone (You are the Peace).html
+++ b/charts/F/For You Alone (You are the Peace).html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/F/Forever (Give Thanks to the Lord).html
+++ b/charts/F/Forever (Give Thanks to the Lord).html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/F/Forever Reign.html
+++ b/charts/F/Forever Reign.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/F/From the Inside Out.html
+++ b/charts/F/From the Inside Out.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/G/Give Thanks.html
+++ b/charts/G/Give Thanks.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/G/Give Us Clean Hands.html
+++ b/charts/G/Give Us Clean Hands.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/G/Glorious Day (Living, He Loved Me).html
+++ b/charts/G/Glorious Day (Living, He Loved Me).html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/G/Glorious Ruin.html
+++ b/charts/G/Glorious Ruin.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/G/Glory (Lift Up Your Heads).html
+++ b/charts/G/Glory (Lift Up Your Heads).html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/G/Go Tell It On The Mountain.html
+++ b/charts/G/Go Tell It On The Mountain.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/G/God Be Praised.html
+++ b/charts/G/God Be Praised.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/G/God I Look To You.html
+++ b/charts/G/God I Look To You.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/G/God Will Make A Way.html
+++ b/charts/G/God Will Make A Way.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/G/God is Able.html
+++ b/charts/G/God is Able.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/G/God is Good All the Time.html
+++ b/charts/G/God is Good All the Time.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/G/God is Here.html
+++ b/charts/G/God is Here.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/G/God is So Good.html
+++ b/charts/G/God is So Good.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/G/God of Ages.html
+++ b/charts/G/God of Ages.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/G/God of Calvary.html
+++ b/charts/G/God of Calvary.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/G/God of Wonders.html
+++ b/charts/G/God of Wonders.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/G/Good Good Father.html
+++ b/charts/G/Good Good Father.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/G/Good Grace.html
+++ b/charts/G/Good Grace.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/G/Goodness of God.html
+++ b/charts/G/Goodness of God.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/G/Great Are You Lord.html
+++ b/charts/G/Great Are You Lord.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/G/Great Awakening.html
+++ b/charts/G/Great Awakening.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/G/Great is Thy Faithfulness (Beginning to End).html
+++ b/charts/G/Great is Thy Faithfulness (Beginning to End).html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/G/Great is Thy Faithfulness.html
+++ b/charts/G/Great is Thy Faithfulness.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/G/Great is the Lord.html
+++ b/charts/G/Great is the Lord.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/H/Hallelujah to the Lamb.html
+++ b/charts/H/Hallelujah to the Lamb.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/H/Happy Birthday to You.html
+++ b/charts/H/Happy Birthday to You.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/H/Have It All.html
+++ b/charts/H/Have It All.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/H/Healer.html
+++ b/charts/H/Healer.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/H/Hear Our Praises.html
+++ b/charts/H/Hear Our Praises.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/H/Heart of Worship.html
+++ b/charts/H/Heart of Worship.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/H/Here I Am to Worship.html
+++ b/charts/H/Here I Am to Worship.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/H/Here I Bow.html
+++ b/charts/H/Here I Bow.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/H/Here for You.html
+++ b/charts/H/Here for You.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/H/Here in Your Presence.html
+++ b/charts/H/Here in Your Presence.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/H/Here is My Song.html
+++ b/charts/H/Here is My Song.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/H/Highlands.html
+++ b/charts/H/Highlands.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/H/Holy Forever.html
+++ b/charts/H/Holy Forever.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/H/Holy Holy Holy (Lord God Almighty).html
+++ b/charts/H/Holy Holy Holy (Lord God Almighty).html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/H/Holy Spirit (You are welcome here).html
+++ b/charts/H/Holy Spirit (You are welcome here).html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/H/Holy is the Lord.html
+++ b/charts/H/Holy is the Lord.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/H/Hosanna (King of Glory).html
+++ b/charts/H/Hosanna (King of Glory).html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/H/Hosanna (Praise is Rising).html
+++ b/charts/H/Hosanna (Praise is Rising).html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/H/How A Broken Spirit.html
+++ b/charts/H/How A Broken Spirit.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/H/How Can I Keep From Singing.html
+++ b/charts/H/How Can I Keep From Singing.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/H/How Deep The Father's Love.html
+++ b/charts/H/How Deep The Father's Love.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/H/How Do I Live Without You.html
+++ b/charts/H/How Do I Live Without You.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/H/How Good It Is (To Give Thanks Unto the Lord).html
+++ b/charts/H/How Good It Is (To Give Thanks Unto the Lord).html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/H/How Great Is Our God.html
+++ b/charts/H/How Great Is Our God.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/H/How Great Thou Art.html
+++ b/charts/H/How Great Thou Art.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/H/How Great You Are.html
+++ b/charts/H/How Great You Are.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/H/How He Loves.html
+++ b/charts/H/How He Loves.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/H/Hymn Of Heaven.html
+++ b/charts/H/Hymn Of Heaven.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/H/Hymn of the Holy Spirit.html
+++ b/charts/H/Hymn of the Holy Spirit.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/I/I Adore.html
+++ b/charts/I/I Adore.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/I/I Could Sing Of Your Love.html
+++ b/charts/I/I Could Sing Of Your Love.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/I/I Exalt Thee.html
+++ b/charts/I/I Exalt Thee.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/I/I Lift My Hands.html
+++ b/charts/I/I Lift My Hands.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/I/I Love You, Lord.html
+++ b/charts/I/I Love You, Lord.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/I/I Need You More.html
+++ b/charts/I/I Need You More.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/I/I Raise a Hallelujah.html
+++ b/charts/I/I Raise a Hallelujah.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/I/I Simply Live for You.html
+++ b/charts/I/I Simply Live for You.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/I/I Want to be Where You Are.html
+++ b/charts/I/I Want to be Where You Are.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/I/I Will Celebrate, Sing Unto the Lord.html
+++ b/charts/I/I Will Celebrate, Sing Unto the Lord.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/I/I Will Give Thanks to Thee.html
+++ b/charts/I/I Will Give Thanks to Thee.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/I/I Will Rise.html
+++ b/charts/I/I Will Rise.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/I/I Will Run to You.html
+++ b/charts/I/I Will Run to You.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/I/I Worship You, Almighty God.html
+++ b/charts/I/I Worship You, Almighty God.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/I/I will Sing of the Mercies of the Lord.html
+++ b/charts/I/I will Sing of the Mercies of the Lord.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/I/In Christ Alone.html
+++ b/charts/I/In Christ Alone.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/I/In Jesus' Name.html
+++ b/charts/I/In Jesus' Name.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/I/In Moments Like This.html
+++ b/charts/I/In Moments Like This.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/I/In the Presence of the Holy God.html
+++ b/charts/I/In the Presence of the Holy God.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/I/Indescribable.html
+++ b/charts/I/Indescribable.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/I/It is Well (Let Go My Soul).html
+++ b/charts/I/It is Well (Let Go My Soul).html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/I/It is Well (You are the Rock).html
+++ b/charts/I/It is Well (You are the Rock).html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/I/It is Well.html
+++ b/charts/I/It is Well.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/I/It's Christmas.html
+++ b/charts/I/It's Christmas.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/J/Jesus I Come.html
+++ b/charts/J/Jesus I Come.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/J/Jesus Lover of My Soul.html
+++ b/charts/J/Jesus Lover of My Soul.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/J/Jesus Shall Take the Highest Honour.html
+++ b/charts/J/Jesus Shall Take the Highest Honour.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/J/Jesus The Centre of It All.html
+++ b/charts/J/Jesus The Centre of It All.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/J/Jesus We Enthrone You.html
+++ b/charts/J/Jesus We Enthrone You.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/J/Jesus the Same.html
+++ b/charts/J/Jesus the Same.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/J/Joy (You've turned it all around).html
+++ b/charts/J/Joy (You've turned it all around).html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/K/King of Kings.html
+++ b/charts/K/King of Kings.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/K/King of My Heart.html
+++ b/charts/K/King of My Heart.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/L/Let the Heavens Rejoice.html
+++ b/charts/L/Let the Heavens Rejoice.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/L/Let the Peace of God Reign.html
+++ b/charts/L/Let the Peace of God Reign.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/L/Light the Fire Again.html
+++ b/charts/L/Light the Fire Again.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/L/Lion and the Lamb.html
+++ b/charts/L/Lion and the Lamb.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/L/Living Hope.html
+++ b/charts/L/Living Hope.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/L/Lord Your Goodness.html
+++ b/charts/L/Lord Your Goodness.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/L/Lord, I Offer My Life to You.html
+++ b/charts/L/Lord, I Offer My Life to You.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/L/Love of God.html
+++ b/charts/L/Love of God.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/M/Made Me Glad.html
+++ b/charts/M/Made Me Glad.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/M/Magnificent.html
+++ b/charts/M/Magnificent.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/M/Majesty (Here I Am).html
+++ b/charts/M/Majesty (Here I Am).html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/M/Majesty.html
+++ b/charts/M/Majesty.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/M/Making A Difference.html
+++ b/charts/M/Making A Difference.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/M/Man of Sorrows.html
+++ b/charts/M/Man of Sorrows.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/M/Mighty To Save.html
+++ b/charts/M/Mighty To Save.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/M/My Greatest Love is You.html
+++ b/charts/M/My Greatest Love is You.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/M/My Redeemer Lives.html
+++ b/charts/M/My Redeemer Lives.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/N/New Doxology.html
+++ b/charts/N/New Doxology.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/N/No Longer Slaves.html
+++ b/charts/N/No Longer Slaves.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/O/O Come All Ye Faithful.html
+++ b/charts/O/O Come All Ye Faithful.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/O/O Come To The Altar.html
+++ b/charts/O/O Come To The Altar.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/O/O Praise the Name (Anatasis).html
+++ b/charts/O/O Praise the Name (Anatasis).html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/O/Oceans.html
+++ b/charts/O/Oceans.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/O/Offering (The Sun Cannot Compare).html
+++ b/charts/O/Offering (The Sun Cannot Compare).html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/O/Oh Lord, Youre Beautiful.html
+++ b/charts/O/Oh Lord, Youre Beautiful.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/O/Oh the Glory of His Presence.html
+++ b/charts/O/Oh the Glory of His Presence.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/O/Once Again.html
+++ b/charts/O/Once Again.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/O/One Day (so blessed).html
+++ b/charts/O/One Day (so blessed).html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/O/One Desire.html
+++ b/charts/O/One Desire.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/O/One Thing Remains.html
+++ b/charts/O/One Thing Remains.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/O/One Voice.html
+++ b/charts/O/One Voice.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/O/One Way.html
+++ b/charts/O/One Way.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/O/Only By Grace.html
+++ b/charts/O/Only By Grace.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/O/Only a Holy God.html
+++ b/charts/O/Only a Holy God.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/O/Open Spaces.html
+++ b/charts/O/Open Spaces.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/O/Open the Eyes of my Heart.html
+++ b/charts/O/Open the Eyes of my Heart.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/O/Our Father (Hillsongs).html
+++ b/charts/O/Our Father (Hillsongs).html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/O/Our Father.html
+++ b/charts/O/Our Father.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/O/Our God (is Greater).html
+++ b/charts/O/Our God (is Greater).html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/P/Potter's Hand.html
+++ b/charts/P/Potter's Hand.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/P/Praise the Lord (Psalm 150).html
+++ b/charts/P/Praise the Lord (Psalm 150).html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/P/Prepare the Way.html
+++ b/charts/P/Prepare the Way.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/R/Refiner's Fire.html
+++ b/charts/R/Refiner's Fire.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/R/Reign King Jesus Reign.html
+++ b/charts/R/Reign King Jesus Reign.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/R/Revelation Song.html
+++ b/charts/R/Revelation Song.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/R/Reward.html
+++ b/charts/R/Reward.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/S/Sanctuary (City Harvest).html
+++ b/charts/S/Sanctuary (City Harvest).html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/S/Say to the Lord I Love You.html
+++ b/charts/S/Say to the Lord I Love You.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/S/Set A Fire.html
+++ b/charts/S/Set A Fire.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/S/Shekinah Glory (We wait for You).html
+++ b/charts/S/Shekinah Glory (We wait for You).html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/S/Shout To The Lord.html
+++ b/charts/S/Shout To The Lord.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/S/Shout of the King.html
+++ b/charts/S/Shout of the King.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/S/Sing (Your Love).html
+++ b/charts/S/Sing (Your Love).html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/S/So You Would Come.html
+++ b/charts/S/So You Would Come.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/S/Speak to Me (I am Your servant).html
+++ b/charts/S/Speak to Me (I am Your servant).html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/S/Spirit Break Out.html
+++ b/charts/S/Spirit Break Out.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/S/Spirit, Touch Your Church.html
+++ b/charts/S/Spirit, Touch Your Church.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/S/Still.html
+++ b/charts/S/Still.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/S/Sweet Surrender.html
+++ b/charts/S/Sweet Surrender.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/T/Take My Life and Let It Be.html
+++ b/charts/T/Take My Life and Let It Be.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/T/Tell The World.html
+++ b/charts/T/Tell The World.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/T/Thank You Jesus For the Blood.html
+++ b/charts/T/Thank You Jesus For the Blood.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/T/Thank You Jesus.html
+++ b/charts/T/Thank You Jesus.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/T/Thank You Lord for Saving My Soul.html
+++ b/charts/T/Thank You Lord for Saving My Soul.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/T/Thank You for the Cross (Mighty Cross).html
+++ b/charts/T/Thank You for the Cross (Mighty Cross).html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/T/The Servant King.html
+++ b/charts/T/The Servant King.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/T/The Stand.html
+++ b/charts/T/The Stand.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/T/There is None Like You.html
+++ b/charts/T/There is None Like You.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/T/This I Believe (The Creed).html
+++ b/charts/T/This I Believe (The Creed).html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/T/This Is Amazing Grace.html
+++ b/charts/T/This Is Amazing Grace.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/T/This Kingdom.html
+++ b/charts/T/This Kingdom.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/T/This is My Desire.html
+++ b/charts/T/This is My Desire.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/T/This is Our God.html
+++ b/charts/T/This is Our God.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/T/This is the Day.html
+++ b/charts/T/This is the Day.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/T/Through It All.html
+++ b/charts/T/Through It All.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/T/Till I See You.html
+++ b/charts/T/Till I See You.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/T/To Our God.html
+++ b/charts/T/To Our God.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/T/To You (Lord of the Heavens).html
+++ b/charts/T/To You (Lord of the Heavens).html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/T/Touch of Heaven.html
+++ b/charts/T/Touch of Heaven.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/T/Touching Heaven Changing Earth.html
+++ b/charts/T/Touching Heaven Changing Earth.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/T/Turn Your Eyes (Sovereign Grace).html
+++ b/charts/T/Turn Your Eyes (Sovereign Grace).html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/T/Turn Your Eyes Upon Jesus.html
+++ b/charts/T/Turn Your Eyes Upon Jesus.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/U/Unchanging (Raise Up Holy Hands).html
+++ b/charts/U/Unchanging (Raise Up Holy Hands).html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/U/Unfailing Love.html
+++ b/charts/U/Unfailing Love.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/V/Victor's Crown.html
+++ b/charts/V/Victor's Crown.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/W/Waiting Here for You.html
+++ b/charts/W/Waiting Here for You.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/W/Way Maker.html
+++ b/charts/W/Way Maker.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/W/We Bow Down.html
+++ b/charts/W/We Bow Down.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/W/We Bring a Sacrifice of Praise.html
+++ b/charts/W/We Bring a Sacrifice of Praise.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/W/We Fall Down.html
+++ b/charts/W/We Fall Down.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/W/We Want to See Jesus Lifted High.html
+++ b/charts/W/We Want to See Jesus Lifted High.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/W/What Can I Do.html
+++ b/charts/W/What Can I Do.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/W/What a Beautiful Name.html
+++ b/charts/W/What a Beautiful Name.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/W/What a Friend We Have in Jesus.html
+++ b/charts/W/What a Friend We Have in Jesus.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/W/When It's All Been Said and Done.html
+++ b/charts/W/When It's All Been Said and Done.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/W/Who Am I.html
+++ b/charts/W/Who Am I.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/W/Who You Say I Am.html
+++ b/charts/W/Who You Say I Am.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/W/Whole Heart (Hold Me Now).html
+++ b/charts/W/Whole Heart (Hold Me Now).html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/W/Whom Shall I Fear.html
+++ b/charts/W/Whom Shall I Fear.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/W/With All I Am.html
+++ b/charts/W/With All I Am.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/W/Worthy Of It All.html
+++ b/charts/W/Worthy Of It All.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/W/Worthy is the Lamb.html
+++ b/charts/W/Worthy is the Lamb.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/Y/Yet Not I But Through Christ in Me.html
+++ b/charts/Y/Yet Not I But Through Christ in Me.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/Y/You Alone Can Rescue.html
+++ b/charts/Y/You Alone Can Rescue.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/Y/You Are Beautiful Beyond Description.html
+++ b/charts/Y/You Are Beautiful Beyond Description.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/Y/You Are God Alone.html
+++ b/charts/Y/You Are God Alone.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/Y/You Are Good (I sing because You are good).html
+++ b/charts/Y/You Are Good (I sing because You are good).html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/Y/You Are Good (Your Kindness Leads Me To Repentance).html
+++ b/charts/Y/You Are Good (Your Kindness Leads Me To Repentance).html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/Y/You Are Here (in our midst).html
+++ b/charts/Y/You Are Here (in our midst).html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/Y/You Are Holy.html
+++ b/charts/Y/You Are Holy.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/Y/You Are My King (Amazing Love).html
+++ b/charts/Y/You Are My King (Amazing Love).html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/Y/You Are the God that Healeth Me.html
+++ b/charts/Y/You Are the God that Healeth Me.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/Y/You Crown the Year.html
+++ b/charts/Y/You Crown the Year.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/Y/You Laid Aside Your Majesty.html
+++ b/charts/Y/You Laid Aside Your Majesty.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/Y/You Make Me Brave.html
+++ b/charts/Y/You Make Me Brave.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/Y/You Won't Relent.html
+++ b/charts/Y/You Won't Relent.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/Y/You are + You are Lord.html
+++ b/charts/Y/You are + You are Lord.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/Y/You are Holy (Prince of Peace).html
+++ b/charts/Y/You are Holy (Prince of Peace).html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/Y/You are My World.html
+++ b/charts/Y/You are My World.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/Y/You are so Faithful.html
+++ b/charts/Y/You are so Faithful.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/Y/Your Grace is Enough.html
+++ b/charts/Y/Your Grace is Enough.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/Y/Your Great Name.html
+++ b/charts/Y/Your Great Name.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/Y/Your Love Never Fails.html
+++ b/charts/Y/Your Love Never Fails.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/Y/Your Love is Amazing.html
+++ b/charts/Y/Your Love is Amazing.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/Y/Your Name High.html
+++ b/charts/Y/Your Name High.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/Y/Your Name.html
+++ b/charts/Y/Your Name.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/Y/Your Presence is Heaven to Me.html
+++ b/charts/Y/Your Presence is Heaven to Me.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/Y/Your Unfailing Love.html
+++ b/charts/Y/Your Unfailing Love.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/chartDir.html
+++ b/charts/chartDir.html
@@ -50,7 +50,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/charts/number/10,000 Reasons.html
+++ b/charts/number/10,000 Reasons.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/generateDoc.html
+++ b/generateDoc.html
@@ -48,7 +48,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/search/search.html
+++ b/search/search.html
@@ -89,7 +89,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>

--- a/template/template.html
+++ b/template/template.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <a href="http://ryan2706.github.io/GEAR/generateDoc.html" title="Generate Document">
-            <i class="bi bi-filetype-docx collapsed-element"></i>
+            <span class="glyphicon glyphicon-save-file"></span>
           </a>
         </li>
         <li>


### PR DESCRIPTION
## Summary
- replace Bootstrap docx icon tag with glyphicon save-file markup across all HTML files

## Testing
- `npm test` (fails: Could not read package.json)
- `python -m pytest` (no tests ran)


------
https://chatgpt.com/codex/tasks/task_e_688e160d6840833390c138720506d946